### PR TITLE
Protect STDIN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/erb_transformer.rb
+++ b/erb_transformer.rb
@@ -1,0 +1,4 @@
+require 'erb'
+
+delimiter = ARGV[0]
+puts "#{delimiter}#{ERB.new(STDIN.read).result}#{delimiter}"

--- a/index.js
+++ b/index.js
@@ -1,13 +1,19 @@
 var exec = require('child_process').exec;
+var path = require('path');
+var uuid = require('node-uuid');
 
 module.exports = function(source, map) {
 
   var callback = this.async();
 
+  var ioDelimiter = uuid.v4();
   var child = exec(
-    "./bin/rails runner 'require \"erb\"; puts ERB.new(STDIN.read).result()'",
-    function(error, result) {
-      callback(error, result, map);
+    './bin/rails runner ' + path.join(__dirname, 'erb_transformer.rb') + ' ' + ioDelimiter,
+    function(error, stdout) {
+      var sourceRegex = new RegExp(ioDelimiter + '([\\s\\S]+)' + ioDelimiter);
+      var matches = stdout.match(sourceRegex);
+      var transformedSource = matches && matches[1];
+      callback(error, transformedSource, map);
     }
   );
 

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/usabilityhub/erb-loader/issues"
   },
-  "homepage": "https://github.com/usabilityhub/erb-loader#readme"
+  "homepage": "https://github.com/usabilityhub/erb-loader#readme",
+  "dependencies": {
+    "node-uuid": "^1.4.7"
+  }
 }


### PR DESCRIPTION
- In build environments where data is being written to STDIN, it will receive unwanted data in addition to the file
- By surrounding our Ruby `puts` with delimiters we can ignore any garbage that was written to STDIN during the build