### PR TITLE
Feature/caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,23 @@
-# ERB loader
-[![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
+# uh-erb-loader
 
-Simple `.erb` loader for use with Webpack in a Ruby on Rails project. Files are piped through the `ERB` via a `rails runner` call on commandline (see source for more info).
+[![Standard - JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
+[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
-## Installation
+> Embedded Ruby (`.erb`) Webpack loader for Ruby on Rails projects.
+
+Compiles Embedded Ruby template files in a Rails project. Files are piped through the `ERB` gem via a call to `rails runner`.
+
+## Install
 
 Install from npm
 
-```bash
+```console
 $ npm install uh-erb-loader --save-dev
 ```
 
-## Example Webpack config
+## Usage
+
+Add `uh-erb-loader` to your preloaders.
 
 ```js
 // webpack.config.js
@@ -22,3 +28,62 @@ module.exports = {
   ]
 };
 ```
+
+## Configuration
+
+Can be configured with [query parameters](https://webpack.github.io/docs/using-loaders.html#query-parameters):
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `cacheable` | `false` | Should this file be cached? If `false` files will recompiled on every build. Files that have [configuration comments](#dependencies) will always be cached. |
+| `dependenciesRoot` | `"app"` | The root of your Rails project, relative to Webpack's working directory. |
+| `parseComments` | `true` | Search files for configuration comments before compiling. |
+
+## Dependencies
+
+Building many `.erb` files can be slow. It is best to be avoided when unnecessary. You can speed up rebuild by whitelisting dependencies from your Rails project.
+
+For example, consider the following React component that reads data from the `User` and `Image` Ruby classes:
+
+```erb
+// app/assets/javascripts/UserFormFields.js
+
+/* uh-erb-loader-dependencies models/user models/image */
+
+export default function UserFormFields() {
+  return (
+    <div>
+      <label>Avatar</label>
+      <ImageField maxSize={<%= Image::MAX_SIZE %>} />
+      <input
+        id='name'
+        type='text'
+        maxLength={<%= User::MAX_NAME_LENGTH %>}
+      />
+      <label htmlFor='name'>Name</label>
+      <input
+        id='name'
+        type='text'
+        maxLength={<%= User::MAX_NAME_LENGTH %>}
+      />
+      <label htmlFor='age'>Age</label>
+      <input
+        id='age'
+        type='number'
+        min={<%= User::MIN_AGE %>}
+        max={<%= User::MAX_AGE %>}
+      />
+    </div>
+  )
+}
+```
+
+Inclusion of the `uh-erb-loader-dependency` (or `-dependencies`) comment will tell Webpack to cache the file until any of the listed dependencies are modified.
+
+## Contribute
+
+Questions, bug reports and pull requests welcome. See [GitHub issues](https://github.com/usabilityhub/uh-erb-loader/issues).
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -31,15 +31,29 @@ module.exports = {
 
 ## Configuration
 
+### Query parameters
+
 Can be configured with [query parameters](https://webpack.github.io/docs/using-loaders.html#query-parameters):
 
 | Option | Default | Description |
 | ------ | ------- | ----------- |
-| `cacheable` | `false` | Should this file be cached? If `false` files will recompiled on every build. Files that have [configuration comments](#dependencies) will always be cached. |
+| `cacheable` | `false` | If `false`, then files are rebuilt every time WebPack rebuilds. If `true`, files will only be rebuilt when they or their dependencies are modified. |
+| `dependencies` | `[]` | A list of Ruby files to watch for changes. |
 | `dependenciesRoot` | `"app"` | The root of your Rails project, relative to Webpack's working directory. |
-| `parseComments` | `true` | Search files for configuration comments before compiling. |
+| `parseComments` | `true` | Search files for [configuration comments](#configuration-comments) before compiling. |
 
-## Dependencies
+### Configuration comments
+
+#### `uh-erb-loader-cacheable`
+
+Override `cacheable` config for just this file.
+
+```js
+/* uh-erb-loader-cacheable true */
+export const VALUE = <%= 5 %>
+```
+
+#### `uh-erb-loader-dependencies`
 
 Building many `.erb` files can be slow. It is best to be avoided when unnecessary. You can speed up rebuild by whitelisting dependencies from your Rails project.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Can be configured with [query parameters](https://webpack.github.io/docs/using-l
 
 | Option | Default | Description |
 | ------ | ------- | ----------- |
-| `cacheable` | `false` | If `false`, then files are rebuilt every time WebPack rebuilds. If `true`, files will only be rebuilt when they or their dependencies are modified. |
+| `cacheable` | `true` | If `false`, then files are rebuilt every time WebPack rebuilds. If `true`, files will only be rebuilt when they or their dependencies are modified. |
 | `dependencies` | `[]` | A list of Ruby files to watch for changes. |
 | `dependenciesRoot` | `"app"` | The root of your Rails project, relative to Webpack's working directory. |
 | `parseComments` | `true` | Search files for [configuration comments](#configuration-comments) before compiling. |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 
 Compiles Embedded Ruby template files in a Rails project. Files are piped through the `ERB` gem via a call to `rails runner`.
 
+## Table of Contents
+- [Install](#install)
+- [Usage](#usage)
+- [Configuration](#configuration)
+  - [Query parameters](#query-parameters)
+  - [Configuration comments](#configuration-comments)
+- [Contribute](#contribute)
+- [License](#license)
+
 ## Install
 
 Install from npm

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Can be configured with [query parameters](https://webpack.github.io/docs/using-l
 
 ### Configuration comments
 
+`uh-erb-loader` will parse files for overrides to query parameters. These must be `/* ... */` style block comments starting with the correct `uh-erb-loader-*` command. This comment syntax is supported in JavaScript, CSS, SASS and less.
+
 #### `uh-erb-loader-cacheable`
 
 Override `cacheable` config for just this file.

--- a/index.js
+++ b/index.js
@@ -1,21 +1,87 @@
 var exec = require('child_process').exec
 var path = require('path')
 var uuid = require('node-uuid')
+var loaderUtils = require('loader-utils')
+var defaults = require('lodash.defaults')
 
-module.exports = function (source, map) {
-  var callback = this.async()
+/* Match any block comments that start with the string `uh-erb-loader-dependency` or
+ * `uh-erb-loader-dependencies`. The rest of the comment should be a list of paths
+ * to Ruby files within the project structure.
+ */
+var dependenciesRegex = /(?:\/\*\s*uh-erb-loader-dependenc(?:y|ies))\s*([\s\S]*?)(?:\s*\*\/)/g
 
+/* Match any path ending with a file extension */
+var fileExtensionRegex = /\.\w*$/
+
+/* Takes a path and attaches `.rb` if it does not already have an extension. */
+function defaultFileExtension (dependency) {
+  return fileExtensionRegex.test(dependency) ? dependency : dependency + '.rb'
+}
+
+/* Get a list of all dependencies listed in `dependencies` comments. */
+function getDependencies (source, root) {
+  var match = null
+  var dependencies = []
+  while ((match = dependenciesRegex.exec(source))) {
+    // Get each space separated path, ignoring any empty strings.
+    match[1].split(/\s+/).forEach(function (simpleDependency) {
+      if (simpleDependency.length > 0) {
+        var dependency = path.resolve(root, defaultFileExtension(simpleDependency))
+        dependencies.push(dependency)
+      }
+    })
+  }
+  return dependencies
+}
+
+/* Launch Rails in a child process and run the `erb_transformer.rb` script to
+ * output transformed source.
+ */
+function transformSource (source, map, callback) {
   var ioDelimiter = uuid.v4()
   var child = exec(
     './bin/rails runner ' + path.join(__dirname, 'erb_transformer.rb') + ' ' + ioDelimiter,
     function (error, stdout) {
+      // Output is delimited to filter out unwanted warnings or other output
+      // that we don't want in our files.
       var sourceRegex = new RegExp(ioDelimiter + '([\\s\\S]+)' + ioDelimiter)
       var matches = stdout.match(sourceRegex)
       var transformedSource = matches && matches[1]
       callback(error, transformedSource, map)
     }
   )
-
   child.stdin.write(source)
   child.stdin.end()
+}
+
+module.exports = function uhErbLoader (source, map) {
+  var loader = this
+
+  // Get options passed in the loader query, or use defaults.
+  var config = defaults(loaderUtils.getLoaderConfig(loader, 'uhErbLoader'), {
+    cacheable: false,
+    dependenciesRoot: 'app',
+    parseComments: true
+  })
+
+  // If `parseComments` is enabled then search the files for dependency
+  // commands.
+  var dependencies = config.parseComments
+    ? getDependencies(source, config.dependenciesRoot)
+    : []
+
+  if (dependencies.length > 0) {
+    // Automatically enable caching if any dependencies are found, and register
+    // them all with Webpack...
+    loader.cacheable()
+    dependencies.forEach(function (dependency) {
+      loader.addDependency(dependency)
+    })
+  } else if (config.cacheable) {
+    // ...Otherwise use the default `cacheable` setting.
+    loader.cacheable()
+  }
+  // Now actually transform the source.
+  var callback = loader.async()
+  transformSource(source, map, callback)
 }

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ module.exports = function uhErbLoader (source, map) {
 
   // Get options passed in the loader query, or use defaults.
   var config = defaults(loaderUtils.getLoaderConfig(loader, 'uhErbLoader'), {
-    cacheable: false,
+    cacheable: true,
     dependencies: [],
     dependenciesRoot: 'app',
     parseComments: true

--- a/index.js
+++ b/index.js
@@ -68,7 +68,6 @@ function parseComments (source, config) {
         )
     }
   }
-  return config
 }
 
 /* Launch Rails in a child process and run the `erb_transformer.rb` script to

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "homepage": "https://github.com/usabilityhub/erb-loader#readme",
   "dependencies": {
+    "loader-utils": "^0.2.16",
+    "lodash.defaults": "^4.2.0",
     "node-uuid": "^1.4.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uh-erb-loader",
   "version": "1.1.0",
-  "description": "Embedded Ruby (erb) loader for Webpack",
+  "description": "Embedded Ruby (`.erb`) Webpack loader for Ruby on Rails projects.",
   "main": "index.js",
   "scripts": {
     "lint": "eslint index.js",


### PR DESCRIPTION
Hey @jdlehman, I just implemented a new feature to cut down build time.

Because I originally didn't include `this.cacheable()` in the loader, Webpack would rebuild all `.erb` files on every file change (even if just some unrelated JS file). This means an extra 2-3 seconds before the hot reloader will refresh the page for us.

This PR adds support for the following config options `cacheable`, `dependenciesRoot`, and `parseComments`.

The default behaviour for the loader is to parse each `*.erb` file for JavaScript block comments starting with `uh-erb-loader-dependency`. If found, the module will be set to "cacheable", and will only be recompiled if the file itself is changed or if one of its listed dependencies changes.

If not found, the module will use the config bool "cacheable" to determine whether to cache or not. By default this is "false", which means that it will behave the same as the previous versions unless you tell it otherwise.

There's more info and an example in the README